### PR TITLE
Create BaseRepository interface with CRUD methods and default method closeStatement

### DIFF
--- a/src/main/java/org/riders/sharing/repository/BaseRepository.java
+++ b/src/main/java/org/riders/sharing/repository/BaseRepository.java
@@ -1,4 +1,4 @@
-package repository;
+package org.riders.sharing.repository;
 
 import org.apache.logging.log4j.LogManager;
 import org.riders.sharing.model.BaseEntity;

--- a/src/main/java/org/riders/sharing/repository/BaseRepository.java
+++ b/src/main/java/org/riders/sharing/repository/BaseRepository.java
@@ -14,7 +14,7 @@ public interface BaseRepository<T extends BaseEntity> {
 
     T update(T entity);
 
-    Optional<T> findById(UUID id);
+    Optional<T> find(UUID id);
 
     List<T> findAll();
 

--- a/src/main/java/repository/BaseRepository.java
+++ b/src/main/java/repository/BaseRepository.java
@@ -1,0 +1,34 @@
+package repository;
+
+import org.apache.logging.log4j.LogManager;
+import org.riders.sharing.model.BaseEntity;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BaseRepository<T extends BaseEntity> {
+    T save(BaseEntity entity);
+
+    T update(T entity);
+
+    Optional<T> findById(UUID id);
+
+    List<T> findAll();
+
+    boolean isExist(T entity);
+
+    T delete(UUID id);
+
+    default void closeStatement(Statement statement) {
+        if (statement != null) {
+            try {
+                statement.close();
+            } catch (SQLException e) {
+                LogManager.getLogger(this).error("Can't close statement", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created the BaseRepository interface, which includes abstract methods:

save()

update()

find()

findAll()

isExist()

delete()

Added a default closeStatement() method for handling database statement closure.